### PR TITLE
add support for mongodb 4.4 and ubuntu 20.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ MongoDB support matrix:
 mongodb_package: mongodb-org
 
 # You can control installed version via this param.
-# Should be '3.4', '3.6', '4.0' or '4.2'. This role doesn't support MongoDB < 3.4.
+# Should be '3.4', '3.6', '4.0', '4.2', '4.4'. This role doesn't support MongoDB < 3.4.
 # I will recommend you to use latest version of MongoDB.
-mongodb_version: "4.2"
+mongodb_version: "4.4"
 
 mongodb_pymongo_from_pip: true # Install latest PyMongo via PIP or package manager
 mongodb_pymongo_pip_version: 3.6.1 # Choose PyMong version to install from pip. If not set use latest

--- a/README.md
+++ b/README.md
@@ -10,16 +10,17 @@ Ansible role which manages [MongoDB](http://www.mongodb.org/).
 
 MongoDB support matrix:
 
-| Distribution   | < MongoDB 3.2 |    MongoDB 3.4     |    MongoDB 3.6     |    MongoDB 4.0     |   MongoDB 4.2      |
-| -------------- | :-----------: | :----------------: | :----------------: | :----------------: | :----------------: |
-| Ubuntu 14.04   |  :no_entry:   | :white_check_mark: | :white_check_mark: | :white_check_mark: |        :x:         |
-| Ubuntu 16.04   |  :no_entry:   | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-| Ubuntu 18.04   |  :no_entry:   |        :x:         |        :x:         | :white_check_mark: | :white_check_mark: |
-| Debian 8.x     |  :no_entry:   | :white_check_mark: | :white_check_mark: | :white_check_mark: |        :x:         |
-| Debian 9.x     |  :no_entry:   |        :x:         | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-| RHEL 6.x       |  :no_entry:   | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-| RHEL 7.x       |  :no_entry:   | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-| Amazon Linux 2 |  :no_entry:   | :white_check_mark: |        :x:         | :white_check_mark: | :white_check_mark: |
+| Distribution   | < MongoDB 3.2 |    MongoDB 3.4     |    MongoDB 3.6     |    MongoDB 4.0     |   MongoDB 4.2      |   MongoDB 4.4      |
+| -------------- | :-----------: | :----------------: | :----------------: | :----------------: | :----------------: | :----------------: |
+| Ubuntu 14.04   |  :no_entry:   | :white_check_mark: | :white_check_mark: | :white_check_mark: |        :x:         | :interrobang:      |
+| Ubuntu 16.04   |  :no_entry:   | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :interrobang:      |
+| Ubuntu 18.04   |  :no_entry:   |        :x:         |        :x:         | :white_check_mark: | :white_check_mark: | :interrobang:      |
+| Ubuntu 20.04   |  :no_entry:   |        :x:         |        :x:         | :interrobang:      | :interrobang:      | :white_check_mark: |
+| Debian 8.x     |  :no_entry:   | :white_check_mark: | :white_check_mark: | :white_check_mark: |        :x:         | :interrobang:      |
+| Debian 9.x     |  :no_entry:   |        :x:         | :white_check_mark: | :white_check_mark: | :white_check_mark: | :interrobang:      |
+| RHEL 6.x       |  :no_entry:   | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :interrobang:      |
+| RHEL 7.x       |  :no_entry:   | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :interrobang:      |
+| Amazon Linux 2 |  :no_entry:   | :white_check_mark: |        :x:         | :white_check_mark: | :white_check_mark: | :interrobang:      |
 
 - :white_check_mark: - fully tested, should works fine
 - :interrobang: - maybe works, not tested
@@ -35,7 +36,7 @@ MongoDB support matrix:
 mongodb_package: mongodb-org
 
 # You can control installed version via this param.
-# Should be '3.4', '3.6', '4.0', '4.2', '4.4'. This role doesn't support MongoDB < 3.4.
+# Should be '3.4', '3.6', '4.0', '4.2', or '4.4'. This role doesn't support MongoDB < 3.4.
 # I will recommend you to use latest version of MongoDB.
 mongodb_version: "4.4"
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,15 +2,17 @@
 
 mongodb_package: mongodb-org
 mongodb_package_state: present
-mongodb_version: "4.2"
+mongodb_version: "4.4"
 mongodb_apt_keyserver: keyserver.ubuntu.com
 mongodb_apt_key_id:
   "3.4": "0C49F3730359A14518585931BC711F9BA15703C6"
   "3.6": "2930ADAE8CAF5059EE73BB4B58712A2291FA4AD5"
   "4.0": "9DA31620334BD75D9DCB49F368818C72E52529D4"
   "4.2": "E162F504A20CDF15827F718D4B7C549A058F8B6B"
+  "4.4": "20691eec35216c63caf66ce1656408e390cfb1f5"
 
 mongodb_pymongo_from_pip: true                   # Install latest PyMongo via PIP or package manager
+python_pip_package: "{{ 'python3-pip' if ('focal' == ansible_distribution_release) else 'python-pip' }}"  # python3 for Ubuntu focal
 mongodb_pymongo_pip_version: 3.7.1
 
 mongodb_user_update_password: "on_create"        # MongoDB user password update default policy

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -13,6 +13,7 @@ galaxy_info:
         - trusty
         - xenial
         - bionic
+        - focal
     - name: Debian
       versions:
         - jessie

--- a/tasks/install.debian.yml
+++ b/tasks/install.debian.yml
@@ -91,7 +91,7 @@
 - name: Install PIP
   apt:
     pkg:
-      - python-dev
+      - "{{ 'python3-dev' if ('python3-pip' == python_pip_package) else 'python-dev' }}"  # different python-dev for python3
       - "{{ python_pip_package }}"
   when: mongodb_pymongo_from_pip | bool
 

--- a/tasks/install.debian.yml
+++ b/tasks/install.debian.yml
@@ -92,13 +92,13 @@
   apt:
     pkg:
       - python-dev
-      - python-pip
+      - "{{ python_pip_package }}"
   when: mongodb_pymongo_from_pip | bool
 
 - name: Install setuptools (required for ansible 2.7+)
   apt:
     pkg:
-      - python-setuptools
+      - "{{ 'python3-setuptools' if ('python3-pip' == python_pip_package) else 'python-setuptools' }}"  # different setuptools for python3
   when: mongodb_pymongo_from_pip | bool
 
 - name: Install PyMongo from PIP

--- a/tasks/install.debian.yml
+++ b/tasks/install.debian.yml
@@ -104,6 +104,7 @@
 - name: Install PyMongo from PIP
   pip:
     name: pymongo
+    executable: "{{ 'pip3' if ('python3-pip' == python_pip_package) else 'pip' }}"  # different pip for python3
     state: "{{ mongodb_pymongo_pip_version is defined | ternary('present', 'latest') }}"
     version: "{{ mongodb_pymongo_pip_version | default(omit) }}"
   when: mongodb_pymongo_from_pip | bool

--- a/vars/Ubuntu.yml
+++ b/vars/Ubuntu.yml
@@ -4,3 +4,4 @@ mongodb_repository:
   "3.6": "deb http://repo.mongodb.org/apt/ubuntu {{ ansible_distribution_release }}/mongodb-org/3.6 multiverse"
   "4.0": "deb http://repo.mongodb.org/apt/ubuntu {{ ansible_distribution_release }}/mongodb-org/4.0 multiverse"
   "4.2": "deb http://repo.mongodb.org/apt/ubuntu {{ ansible_distribution_release }}/mongodb-org/4.2 multiverse"
+  "4.4": "deb http://repo.mongodb.org/apt/ubuntu {{ ansible_distribution_release }}/mongodb-org/4.4 multiverse"


### PR DESCRIPTION
Adds mongodb 4.4 and ubuntu 20.04 support as per UnderGreen/ansible-role-mongodb/pull/235